### PR TITLE
Fix compile errors in AVR Asia strategy

### DIFF
--- a/strategies/AVR_Asia_SingleFile.cs
+++ b/strategies/AVR_Asia_SingleFile.cs
@@ -791,7 +791,6 @@ private void RTM_SaveHWMIfNeeded(double equity)
         #region StateMachine
         private enum SMState { IDLE, ARMED, TRIGGERED, ADDON, LOCKOUT }
         private SMState _state = SMState.IDLE;
-        private int _tradesToday;
         private bool _longAttemptLive;
         private bool _shortAttemptLive;
         private bool _addonLongUsed;
@@ -1040,12 +1039,12 @@ private void RTM_SaveHWMIfNeeded(double equity)
         {
             RTM_OnExecutionUpdate(execution, order);
 
-            if (order != null && order.Name == "ENTRY" && execution.OrderState == OrderState.Filled)
+            if (order != null && order.Name == "ENTRY" && order.OrderState == OrderState.Filled)
             {
                 _tradesToday++;
             }
 
-            if (execution != null && order != null && order.Name != null && order.Name.ToUpper().Contains("STOP") && execution.OrderState == OrderState.Filled)
+            if (order != null && order.Name != null && order.Name.ToUpper().Contains("STOP") && order.OrderState == OrderState.Filled)
             {
                 _coolOffUntil = Time[0].AddMinutes(15);
             }


### PR DESCRIPTION
## Summary
- remove duplicate `_tradesToday` field to avoid type ambiguity
- use order's OrderState in execution handler and adjust trade tracking logic

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c25f666b88329a42aa272b8a4cb57